### PR TITLE
Adds broccoli-cli as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-plugin-transform-proto-to-assign": "^6.9.0",
     "broccoli": "^1.1.0",
     "broccoli-babel-transpiler": "^6.0.0-alpha.1",
+    "broccoli-cli": "^1.0.0",
     "broccoli-concat": "^3.0.5",
     "broccoli-file-creator": "^1.1.1",
     "broccoli-funnel": "^1.1.0",


### PR DESCRIPTION
This is so npm scripts will still work for environments that don’t have broccoli-cli installed globally.