### PR TITLE
First pass at restructuring build output

### DIFF
--- a/lib/to-named-amd.js
+++ b/lib/to-named-amd.js
@@ -1,18 +1,16 @@
 "use strict";
 
 const Babel = require('broccoli-babel-transpiler');
-const funnel = require('broccoli-funnel');
 const moduleResolve = require('amd-name-resolver').moduleResolve;
+const toNamespacedTree = require('./to-namespaced-tree');
 
 module.exports = function toNamedAMD(tree) {
-  let babel = new Babel(tree, {
+  let namespacedTree = toNamespacedTree(tree);
+
+  return new Babel(namespacedTree, {
     moduleIds: true,
     resolveModuleSource: moduleResolve,
     sourceMap: 'inline',
     plugins: [ 'transform-es2015-modules-amd' ]
-  });
-  return funnel(babel, {
-    destDir: 'named-amd',
-    annotation: 'named-amd'
   });
 }

--- a/lib/to-named-common-js.js
+++ b/lib/to-named-common-js.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const Babel = require('broccoli-babel-transpiler');
+
+module.exports = function toNamedCommonJS(tree) {
+  return new Babel(tree, {
+    moduleIds: true,
+    sourceMap: 'inline',
+    plugins: [ 'transform-es2015-modules-commonjs' ]
+  });
+}

--- a/lib/to-namespaced-tree.js
+++ b/lib/to-namespaced-tree.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const funnel = require('broccoli-funnel');
+const getPackageName = require('./get-package-name');
+
+module.exports = function toNamespacedTree(tree) {
+  let projectPath = process.cwd();
+  let namespace = getPackageName(projectPath);
+
+  return funnel(tree, { destDir: namespace });
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
     "babel-plugin-transform-es2015-destructuring": "^6.9.0",
     "babel-plugin-transform-es2015-modules-amd": "^6.8.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
     "babel-plugin-transform-es2015-parameters": "^6.11.4",
     "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
     "babel-plugin-transform-es2015-spread": "^6.8.0",
@@ -43,6 +44,6 @@
     "qunitjs": "^2.0.1",
     "testem": "^1.13.0",
     "tslint": "^3.15.1",
-    "typescript": "2.0.10"
+    "typescript": "^2.1.5"
   }
 }


### PR DESCRIPTION
Addresses #6 

Produces output like:

```
dist
├── amd
│   └── es5
│       ├── container.js
│       ├── …
│       └── resolver.js
├── commonjs
│   ├── es2017
│   │   ├── container.js
│   │   ├── …
│   │   └── resolver.js
│   └── es5
│       ├── container.js
│       ├── …
│       └── resolver.js
└── modules
    ├── es2017
    │   ├── container.js
    │   ├── …
    │   └── resolver.js
    └── es5
        ├── container.js
        ├── …
        └── resolver.js
```