### PR TITLE
Remove assumptions about location of node_modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const toNamedAmd = require('./lib/to-named-amd');
 const toNamedCommonJs = require('./lib/to-named-common-js');
 const toES5 = require('./lib/to-es5');
 const helpers = require('./lib/generate-helpers');
+const path = require('path');
 
 module.exports = function(options) {
   options = options || {};
@@ -48,7 +49,7 @@ module.exports = function(options) {
       annotation: 'test/qunit.{js|css}'
     }));
 
-    trees.push(funnel('./node_modules/@glimmer/build/test-support', {
+    trees.push(funnel(path.join(__dirname, 'test-support'), {
       include: [
         'test-loader.js',
         'index.html'
@@ -60,14 +61,14 @@ module.exports = function(options) {
     trees.push(babelHelpers);
 
     let vendorFiles = [
-      'node_modules/@glimmer/build/test-support/loader-no-conflict.js'
+      path.join(__dirname, 'test-support/loader-no-conflict.js')
     ];
 
     if (options.testDependencies) {
       Array.prototype.push.apply(vendorFiles, options.testDependencies);
     };
 
-    trees.push(concat('./', {
+    trees.push(concat('/', {
       inputFiles: vendorFiles,
       outputFile: 'vendor.js',
       annotation: 'vendor.js'


### PR DESCRIPTION
Fixes #12

Requires a change in `@glimmer/di`:

```diff
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,7 +1,10 @@
 const build = require('@glimmer/build');
+const path = require('path');
+
+const glimmerEnginePath = path.dirname(require.resolve('glimmer-engine/package'));

 module.exports = build({
   testDependencies: [
-    'node_modules/glimmer-engine/dist/amd/glimmer-common.amd.js'
+    path.join(glimmerEnginePath, 'dist/amd/glimmer-common.amd.js')
   ]
 });
```