### PR TITLE
Use `headerFiles` instead of `inputFiles` in `concat()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function(options) {
     };
 
     trees.push(concat('/', {
-      inputFiles: vendorFiles,
+      headerFiles: vendorFiles,
       outputFile: 'vendor.js',
       annotation: 'vendor.js'
     }));


### PR DESCRIPTION
`headerFiles` will maintain the order of the array, while `inputFiles` processes the members alphabetically (believe it or not).