### PR TITLE
Support vendorTrees option to build instead of testDependencies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,17 +50,20 @@ module.exports = function(options) {
     let babelHelpers = writeFile('babel-helpers.js', helpers('amd'));
     trees.push(babelHelpers);
 
-    let vendorFiles = [
-      path.join(__dirname, 'test-support/loader-no-conflict.js')
+    let vendorTrees = options.vendorTrees || [];
+
+    vendorTrees = [
+      funnel(path.join(__dirname, 'test-support'), { include: ['loader-no-conflict.js'] })
     ];
 
-    if (options.testDependencies) {
-      Array.prototype.push.apply(vendorFiles, options.testDependencies);
+    if (options.vendorTrees) {
+      Array.prototype.push.apply(vendorTrees, options.vendorTrees);
     };
 
-    trees.push(concat('/', {
-      headerFiles: vendorFiles,
+    trees.push(concat(mergeTrees(vendorTrees), {
+      inputFiles: ['**/*'],
       outputFile: 'vendor.js',
+      sourceMapConfig: { enabled: false },
       annotation: 'vendor.js'
     }));
 

--- a/lib/build-vendor-package.js
+++ b/lib/build-vendor-package.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const Funnel = require('broccoli-funnel');
+const path = require('path');
+const toES5 = require('./to-es5');
+const toNamedAmd = require('./to-named-amd');
+
+module.exports = function(name, options) {
+  options = options ? options : {};
+  let packageJson = require(name + '/package');
+  let packageDir = path.dirname(require.resolve(name + '/package'));
+
+  if (options.entry && !options.srcDir) {
+    throw new Error('If resolving from a non-package.json entry point, you must supply the srcDirectory.');
+  }
+
+  let entryModule = packageJson['module'] || packageJson['jsnext:main'] || packageJson['main'].replace(/dist\//, 'dist/es6/');
+  let funnelDir = path.join(packageDir, options.entry ? options.srcDir : path.dirname(entryModule));
+
+  let es6 = new Funnel(funnelDir, { include: ['**/*.js'] });
+  let es5Modules = toES5(es6, { sourceMap: 'inline' });
+  return toNamedAmd(es5Modules, name);
+}

--- a/lib/to-named-amd.js
+++ b/lib/to-named-amd.js
@@ -4,8 +4,8 @@ const Babel = require('broccoli-babel-transpiler');
 const moduleResolve = require('amd-name-resolver').moduleResolve;
 const toNamespacedTree = require('./to-namespaced-tree');
 
-module.exports = function toNamedAMD(tree) {
-  let namespacedTree = toNamespacedTree(tree);
+module.exports = function toNamedAMD(tree, namespace) {
+  let namespacedTree = toNamespacedTree(tree, namespace);
 
   return new Babel(namespacedTree, {
     moduleIds: true,

--- a/lib/to-namespaced-tree.js
+++ b/lib/to-namespaced-tree.js
@@ -3,9 +3,8 @@
 const funnel = require('broccoli-funnel');
 const getPackageName = require('./get-package-name');
 
-module.exports = function toNamespacedTree(tree) {
-  let projectPath = process.cwd();
-  let namespace = getPackageName(projectPath);
+module.exports = function toNamespacedTree(tree, namespace) {
+  let packageName = namespace || getPackageName(process.cwd());
 
-  return funnel(tree, { destDir: namespace });
+  return funnel(tree, { destDir: packageName });
 }


### PR DESCRIPTION
This allows for more flexibility in building test dependencies, rather
than relying solely on pre-built dependencies.