### PR TITLE
Rollup each vendor package separately

### DIFF
--- a/lib/build-vendor-package.js
+++ b/lib/build-vendor-package.js
@@ -1,9 +1,9 @@
 "use strict";
 
 const Funnel = require('broccoli-funnel');
+const Rollup = require('broccoli-rollup');
 const path = require('path');
 const toES5 = require('./to-es5');
-const toNamedAmd = require('./to-named-amd');
 
 module.exports = function(name, options) {
   options = options ? options : {};
@@ -16,8 +16,25 @@ module.exports = function(name, options) {
 
   let entryModule = packageJson['module'] || packageJson['jsnext:main'] || packageJson['main'].replace(/dist\//, 'dist/es6/');
   let funnelDir = path.join(packageDir, options.entry ? options.srcDir : path.dirname(entryModule));
+  let sourceEntry = options.entry ? options.entry : path.basename(entryModule);
 
   let es6 = new Funnel(funnelDir, { include: ['**/*.js'] });
-  let es5Modules = toES5(es6, { sourceMap: 'inline' });
-  return toNamedAmd(es5Modules, name);
+  let es5 = toES5(es6, { sourceMap: 'inline' });
+  let moduleId = options.moduleId ? options.moduleId : name;
+  let destination = options.dest ? options.dest + '.js': moduleId + '.js';
+  let external = options.external ? options.external : [];
+  let plugins = options.plugins ? options.plugins : [];
+
+  return new Rollup(es5, {
+    rollup: {
+      external: external,
+      entry: sourceEntry,
+      dest: destination,
+      plugins: plugins,
+      format: 'amd',
+      moduleId: moduleId,
+      exports: 'named'
+    },
+    annotation: destination
+  });
 }


### PR DESCRIPTION
This approach fixes some circular dependency issues encountered using
Babel and exporting AMD. It’s also consistent with the build approach
used within the main Ember repo.