### PR TITLE
Fix build for glimmer packages >= 0.22.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,16 @@ module.exports = function(options) {
       annotation: 'vendor.js'
     }));
 
-    trees.push(compileTypescript('tsconfig.tests.json', projectPath));
+    let compiledTypescript = compileTypescript('tsconfig.tests.json', projectPath);
+    let es2017Modules = filterTypescriptFromTree(compiledTypescript);
+    let es5Modules = toES5(es2017Modules);
+    let es5Amd = funnel(toNamedAmd(es5Modules), {
+      srcDir: projectName
+    });
+
+    trees.push(concat(es5Amd, {
+      outputFile: 'tests.js'
+    }));
   } else {
     let es2017ModulesAndTypes = compileTypescript('tsconfig.json', projectPath);
     let types = selectTypesFromTree(es2017ModulesAndTypes);


### PR DESCRIPTION
This addresses #23. The typescript compiler is building the concatted amd file wrong (prepending `node_modules/` to node module imports), so my current work here manually creates the concatted amd file. Why upgrading to 0.22.0 causes this problem is still unknown to me, which is why this is a WIP--this could be the wrong solution.

This requires changes to tsconfig.tests.json files in the packages that use @glimmer/build, for example:

```diff
 {
   "compilerOptions": {
-    "target": "es5",
-    "module": "amd",
+    "target": "es2017",
+    "module": "es2015",
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "inlineSources": true,
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "outFile": "tests/tests.js",
     "types": ["qunit"]
   },
```