### PR TITLE
Better npm linking support

### DIFF
--- a/lib/build-vendor-package.js
+++ b/lib/build-vendor-package.js
@@ -4,11 +4,22 @@ const Funnel = require('broccoli-funnel');
 const Rollup = require('broccoli-rollup');
 const path = require('path');
 const toES5 = require('./to-es5');
+const resolve = require('resolve');
+const stackTrace = require('stack-trace');
 
 module.exports = function(name, options) {
   options = options ? options : {};
-  let packageJson = require(name + '/package');
-  let packageDir = path.dirname(require.resolve(name + '/package'));
+
+  // To support npm linking `@glimmer/build`, look for the given vendor package
+  // from the caller's file system location, not ours.
+  let callerPath = pathToCaller();
+  let packageJsonPath = resolve.sync(name + '/package.json', {
+    basedir: callerPath
+  });
+
+  // Once we've found the target package, load its package.json.
+  let packageDir = path.dirname(packageJsonPath);
+  let packageJson = require(packageJsonPath);
 
   if (options.entry && !options.srcDir) {
     throw new Error('If resolving from a non-package.json entry point, you must supply the srcDirectory.');
@@ -37,4 +48,10 @@ module.exports = function(name, options) {
     },
     annotation: destination
   });
+}
+
+function pathToCaller() {
+  let stackFrame = stackTrace.get()[2];
+  let stackFrameFile = stackFrame.getFileName();
+  return path.dirname(stackFrameFile);
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "broccoli-typescript-compiler": "^1.0.1",
     "loader.js": "^4.0.11",
     "qunitjs": "^2.0.1",
+    "resolve": "^1.3.2",
+    "stack-trace": "^0.0.9",
     "testem": "^1.13.0",
     "tslint": "^3.15.1",
     "typescript": "^2.1.5"


### PR DESCRIPTION
Previously we were relying on Node's built-in module resolution semantics to find the requested package in `buildVendorPackage`. This change uses the _caller's_ location on disk, rather than the utility function's, to determine where to start looking for the named package.