### PR TITLE
Filter TypeScript files

### DIFF
--- a/lib/compile-typescript.js
+++ b/lib/compile-typescript.js
@@ -13,8 +13,15 @@ module.exports = function compileTypescript(tsconfigFile, projectPath) {
     include: ['lib.*.d.ts']
   });
 
-  let ts = funnel(mergeTrees([libs, projectPath]), {
-    annotation: 'raw source'
+  let src = funnel(projectPath, {
+    include: [
+      'src/**/*.ts',
+      'test/**/*.ts'
+    ]
+  });
+
+  let ts = funnel(mergeTrees([libs, src]), {
+    annotation: 'TypeScript Source'
   });
 
   if (tsconfig.compilerOptions.outFile) {


### PR DESCRIPTION
Previously, we were globbing for every `.ts` file in the project directory. This ends up grabbing `tmp/` and `dist/` as well, so any `ember serve` or other continuous build would infinite loop and crash.