### PR TITLE
Make input TS glob configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+sudo: required
+dist: trusty
+
+node_js:
+  - "6"
+  - "node"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# glimmer-build
+# glimmer-build [![Build Status](https://secure.travis-ci.org/glimmerjs/glimmer-build.svg?branch=master)](http://travis-ci.org/glimmerjs/glimmer-build)
 
 Build tooling for Glimmer libraries.
 

--- a/index.js
+++ b/index.js
@@ -82,7 +82,11 @@ module.exports = function(options) {
       outputFile: 'tests.js'
     }));
   } else {
-    let es2017ModulesAndTypes = compileTypescript(tsconfigPath, projectPath);
+    let es2017ModulesAndTypes = compileTypescript({
+      tsconfigPath,
+      projectPath,
+      include: options.include
+    });
     let types = selectTypesFromTree(es2017ModulesAndTypes);
     let es2017Modules = filterTypescriptFromTree(es2017ModulesAndTypes);
     let es5Modules = toES5(es2017Modules, { sourceMap: 'inline' });

--- a/index.js
+++ b/index.js
@@ -71,14 +71,14 @@ module.exports = function(options) {
       annotation: 'vendor.js'
     }));
 
-    let compiledTypescript = compileTypescript({
+    let compiledTypescript = compileTypescript(
       tsconfigPath, 
       projectPath,
-      include: options.include || [
+      options.include || [
         'src/**/*.ts',
         'test/**/*.ts'
       ]
-    });
+    );
     let es2017Modules = filterTypescriptFromTree(compiledTypescript);
     let es5Modules = toES5(es2017Modules);
     let es5Amd = funnel(toNamedAmd(es5Modules), {
@@ -89,13 +89,13 @@ module.exports = function(options) {
       outputFile: 'tests.js'
     }));
   } else {
-    let es2017ModulesAndTypes = compileTypescript({
+    let es2017ModulesAndTypes = compileTypescript(
       tsconfigPath,
       projectPath,
-      include: options.include || [
+      options.include || [
         'src/**/*.ts'
       ]
-    });
+    );
     let types = selectTypesFromTree(es2017ModulesAndTypes);
     let es2017Modules = filterTypescriptFromTree(es2017ModulesAndTypes);
     let es5Modules = toES5(es2017Modules, { sourceMap: 'inline' });

--- a/index.js
+++ b/index.js
@@ -71,7 +71,14 @@ module.exports = function(options) {
       annotation: 'vendor.js'
     }));
 
-    let compiledTypescript = compileTypescript(tsconfigPath, projectPath);
+    let compiledTypescript = compileTypescript({
+      tsconfigPath, 
+      projectPath,
+      include: options.include || [
+        'src/**/*.ts',
+        'test/**/*.ts'
+      ]
+    });
     let es2017Modules = filterTypescriptFromTree(compiledTypescript);
     let es5Modules = toES5(es2017Modules);
     let es5Amd = funnel(toNamedAmd(es5Modules), {
@@ -85,7 +92,9 @@ module.exports = function(options) {
     let es2017ModulesAndTypes = compileTypescript({
       tsconfigPath,
       projectPath,
-      include: options.include
+      include: options.include || [
+        'src/**/*.ts'
+      ]
     });
     let types = selectTypesFromTree(es2017ModulesAndTypes);
     let es2017Modules = filterTypescriptFromTree(es2017ModulesAndTypes);

--- a/lib/compile-typescript.js
+++ b/lib/compile-typescript.js
@@ -6,18 +6,22 @@ const funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
 const typescript = require('broccoli-typescript-compiler').typescript;
 
-module.exports = function compileTypescript(tsconfigFile, projectPath) {
-  let tsconfig = JSON.parse(fs.readFileSync(tsconfigFile));
+module.exports = function compileTypescript(options) {
+  let { include, tsconfigPath, projectPath } = options;
+
+  include = include || [
+    'src/**/*.ts',
+    'test/**/*.ts'
+  ];
+
+  let tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));
 
   let libs = funnel(findLib('typescript'), {
     include: ['lib.*.d.ts']
   });
 
   let src = funnel(projectPath, {
-    include: [
-      'src/**/*.ts',
-      'test/**/*.ts'
-    ]
+    include 
   });
 
   let ts = funnel(mergeTrees([libs, src]), {

--- a/lib/compile-typescript.js
+++ b/lib/compile-typescript.js
@@ -6,13 +6,7 @@ const funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
 const typescript = require('broccoli-typescript-compiler').typescript;
 
-module.exports = function compileTypescript(options) {
-  let { include, tsconfigPath, projectPath } = options;
-
-  include = include || [
-    'src/**/*.ts'
-  ];
-
+module.exports = function compileTypescript(tsconfigPath, projectPath, include = ['src/**/*.ts']) {
   let tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));
 
   let libs = funnel(findLib('typescript'), {

--- a/lib/compile-typescript.js
+++ b/lib/compile-typescript.js
@@ -10,8 +10,7 @@ module.exports = function compileTypescript(options) {
   let { include, tsconfigPath, projectPath } = options;
 
   include = include || [
-    'src/**/*.ts',
-    'test/**/*.ts'
+    'src/**/*.ts'
   ];
 
   let tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));


### PR DESCRIPTION
Previously we were hardcoding to `src/` and `test/` to prevent infinite looping.