### PR TITLE
Update custom babel plugin to avoid cache invalidation.

### DIFF
--- a/lib/to-es5.js
+++ b/lib/to-es5.js
@@ -2,18 +2,23 @@
 
 const Babel = require('broccoli-babel-transpiler');
 
+function ImportExternalHelpersPlugin() {
+  return {
+    name: 'import-external-helpers',
+    pre: function (file) {
+      file.set('helperGenerator', function (name) {
+        return file.addImport('babel-helpers', name, name);
+      });
+    }
+  };
+}
+
+ImportExternalHelpersPlugin.baseDir = function() { return __dirname; };
+
 module.exports = function toES5(tree, _options) {
   let options = Object.assign({}, _options);
   options.plugins = [
-    function () {
-      return {
-        pre: function (file) {
-          file.set('helperGenerator', function (name) {
-            return file.addImport('babel-helpers', name, name);
-          });
-        }
-      };
-    },
+    [ImportExternalHelpersPlugin],
     ['transform-es2015-template-literals', {loose: true}],
     ['transform-es2015-arrow-functions'],
     ['transform-es2015-destructuring', {loose: true}],


### PR DESCRIPTION
broccoli-babel-transpiler@6 was previously opting out of all caching, but now has been updated to participate in the caching scheme.

This updates the build to avoid cache related warnings.