### PR TITLE
Symlink node_modules for inclusion when compiling TS

### DIFF
--- a/lib/compile-typescript.js
+++ b/lib/compile-typescript.js
@@ -4,20 +4,30 @@ const findLib = require('./find-lib');
 const fs = require('fs');
 const funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
+const path = require('path');
 const typescript = require('broccoli-typescript-compiler').typescript;
 
 module.exports = function compileTypescript(tsconfigPath, projectPath, include = ['src/**/*.ts']) {
   let tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));
 
-  let libs = funnel(findLib('typescript'), {
+  let src = [];
+
+  src.push(funnel(findLib('typescript'), {
     include: ['lib.*.d.ts']
-  });
+  }));
 
-  let src = funnel(projectPath, {
+  src.push(funnel(projectPath, {
     include
-  });
+  }));
 
-  let ts = funnel(mergeTrees([libs, src]), {
+  let node_modules = path.join(projectPath, 'node_modules');
+  if (fs.existsSync(node_modules)) {
+    src.push(funnel(node_modules, {
+      destDir: 'node_modules'
+    }));
+  }
+
+  let ts = funnel(mergeTrees(src), {
     annotation: 'TypeScript Source'
   });
 


### PR DESCRIPTION
This allows broccoli-typescript-compiler to find typings for all 
a project’s dependencies, and the symlinking keeps it cheap.