### PR TITLE
Fix ES module Babel helpers

### DIFF
--- a/lib/generate-external-helpers.js
+++ b/lib/generate-external-helpers.js
@@ -12,12 +12,12 @@ let HELPERS = [
   'possibleConstructorReturn',
   'inherits',
   'createClass',
-  'classCallCheck',
-  'taggedTemplateLiteralLoose'
+  'classCallCheck'
 ].map(function (name) {
   let ast = get(name);
   ast.id = t.identifier(name);
   let code = generate(ast).code;
+
   if (name === 'inherits') {
     // IE 9 and 10 fix
     code = code.replace(/if \(superClass\) Object\.setPrototypeOf \?[^;]*;/, REPLACE);
@@ -31,7 +31,7 @@ let HELPERS = [
 module.exports = function helpers(format) {
   let code = HELPERS.map(function (helper) {
     if (format === 'es') {
-      return 'export ' + helper.code;
+      return 'export let ' + helper.name + ' = ' + helper.code;
     }
     return 'exports.' + helper.name + " = " + helper.code;
   }).join('\n');


### PR DESCRIPTION
This was broken before. You need to use `let` because some of the helpers are anonymous functions, and it was including a helper twice.