### PR TITLE
Rollup AMD builds into a single module

### DIFF
--- a/lib/build-tests-index.js
+++ b/lib/build-tests-index.js
@@ -1,0 +1,20 @@
+const walkSync = require('walk-sync');
+const writeFile = require('broccoli-file-creator');
+
+module.exports = function buldTestsIndex(inputDir, destFile) {
+  let modules = [];
+  let paths = walkSync(inputDir);
+  paths.forEach(path => {
+    if (path.indexOf('-test.') > -1) {
+      let name = path.split('.')[0];
+      modules.push(name);
+    }
+  });
+
+  let imports = modules.map(module => {
+    return `import "./${module}";`;
+  });
+  let contents = imports.join('\n');
+
+  return writeFile(destFile, contents);
+}

--- a/lib/build-vendor-package.js
+++ b/lib/build-vendor-package.js
@@ -4,18 +4,12 @@ const Funnel = require('broccoli-funnel');
 const Rollup = require('broccoli-rollup');
 const path = require('path');
 const toES5 = require('./to-es5');
-const resolve = require('resolve');
-const stackTrace = require('stack-trace');
+const resolvePackage = require('./resolve-package');
 
 module.exports = function(name, options) {
   options = options ? options : {};
 
-  // To support npm linking `@glimmer/build`, look for the given vendor package
-  // from the caller's file system location, not ours.
-  let callerPath = pathToCaller();
-  let packageJsonPath = resolve.sync(name + '/package.json', {
-    basedir: callerPath
-  });
+  let packageJsonPath = resolvePackage(name + '/package.json');
 
   // Once we've found the target package, load its package.json.
   let packageDir = path.dirname(packageJsonPath);
@@ -48,10 +42,4 @@ module.exports = function(name, options) {
     },
     annotation: destination
   });
-}
-
-function pathToCaller() {
-  let stackFrame = stackTrace.get()[2];
-  let stackFrameFile = stackFrame.getFileName();
-  return path.dirname(stackFrameFile);
 }

--- a/lib/compile-typescript.js
+++ b/lib/compile-typescript.js
@@ -7,7 +7,7 @@ const mergeTrees = require('broccoli-merge-trees');
 const path = require('path');
 const typescript = require('broccoli-typescript-compiler').typescript;
 
-module.exports = function compileTypescript(tsconfigPath, projectPath, include = ['src/**/*.ts']) {
+module.exports = function compileTypescript(tsconfigPath, projectPath, srcTrees) {
   let tsconfig = JSON.parse(fs.readFileSync(tsconfigPath));
 
   let src = [];
@@ -16,9 +16,11 @@ module.exports = function compileTypescript(tsconfigPath, projectPath, include =
     include: ['lib.*.d.ts']
   }));
 
-  src.push(funnel(projectPath, {
-    include
-  }));
+  if (srcTrees && srcTrees.length > 0) {
+    Array.prototype.push.apply(src, srcTrees);
+  } else {
+    src.push(projectPath);
+  }
 
   let node_modules = path.join(projectPath, 'node_modules');
   if (fs.existsSync(node_modules)) {

--- a/lib/package-dist.js
+++ b/lib/package-dist.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const funnel = require('broccoli-funnel');
+const path = require('path');
+const resolvePackage = require('./resolve-package');
+
+module.exports = function(name, options = {}) {
+  let format = options.format || 'amd';
+  let lang = options.lang || 'es5';
+  let include = [`dist/${format}/${lang}/**/*.js`];
+
+  return funnel(path.dirname(resolvePackage(`${name}/package.json`)), { include });
+}

--- a/lib/resolve-package.js
+++ b/lib/resolve-package.js
@@ -1,0 +1,18 @@
+const resolve = require('resolve');
+const stackTrace = require('stack-trace');
+const path = require('path');
+
+module.exports = function(name) {
+  // To support npm linking `@glimmer/build`, look for the given vendor package
+  // from the caller's file system location, not ours.
+  let callerPath = pathToCaller();
+  return resolve.sync(name, {
+    basedir: callerPath
+  });
+}
+
+function pathToCaller() {
+  let stackFrame = stackTrace.get()[3];
+  let stackFrameFile = stackFrame.getFileName();
+  return path.dirname(stackFrameFile);
+}

--- a/lib/to-named-amd.js
+++ b/lib/to-named-amd.js
@@ -3,14 +3,29 @@
 const Babel = require('broccoli-babel-transpiler');
 const moduleResolve = require('amd-name-resolver').moduleResolve;
 const toNamespacedTree = require('./to-namespaced-tree');
+const getPackageName = require('./get-package-name');
+const path = require('path');
+const Rollup = require('broccoli-rollup');
 
-module.exports = function toNamedAMD(tree, namespace) {
+module.exports = function toNamedAMD(tree, options = {}) {
+  let namespace = options.namespace || getPackageName(process.cwd());
+  let plugins = options.plugins || [];
+  let entry = options.entry || path.join(namespace, 'index.js');
+  let dest = options.dest || path.join('amd', 'es5', namespace.replace(/\//g, '-').replace('@', '') + '.js');
+  let external = options.external || [];
+
   let namespacedTree = toNamespacedTree(tree, namespace);
 
-  return new Babel(namespacedTree, {
-    moduleIds: true,
-    resolveModuleSource: moduleResolve,
-    sourceMap: 'inline',
-    plugins: [ 'transform-es2015-modules-amd' ]
+  return new Rollup(namespacedTree, {
+    rollup: {
+      entry,
+      dest,
+      external,
+      plugins,
+      format: 'amd',
+      moduleId: namespace,
+      exports: 'named'
+    },
+    annotation: dest
   });
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "babel-plugin-transform-es2015-classes": "^6.14.0",
     "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
     "babel-plugin-transform-es2015-destructuring": "^6.9.0",
-    "babel-plugin-transform-es2015-modules-amd": "^6.8.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
     "babel-plugin-transform-es2015-parameters": "^6.11.4",
     "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",

--- a/test-support/loader-no-conflict.js
+++ b/test-support/loader-no-conflict.js
@@ -1,2 +1,0 @@
-// loader.noConflict({ define: 'enifed' });
-self.enifed = self.define;

--- a/test-support/test-loader.js
+++ b/test-support/test-loader.js
@@ -1,16 +1,9 @@
-/* globals requirejs, require */
+/* globals require */
 
 QUnit.config.autostart = false;
 QUnit.config.urlConfig.push({ id: 'nolint', label: 'Disable Linting' });
 
 setTimeout(function() {
-  for (var moduleName in requirejs.entries) {
-    var isTest = moduleName.match(/[-_]test$/);
-    var isSkippedLintTest = QUnit.urlParams.nolint && moduleName.match(/\.lint-test$/);
-
-    if (isTest && !isSkippedLintTest) {
-      require(moduleName);
-    }
-  }
+  require('tests');
   QUnit.start();
 }, 250);


### PR DESCRIPTION
Shipping AMD builds as separate internal modules was causing circular 
dependency problems in when building the main glimmer repo.

By rolling up AMD distributions, we only export the modules exposed by
the entry point (index.js). This leads to leaner AMD builds and better
encapsulation, since internals can not be directly accessed.

This approach requires building an entry point module for tests which
imports all the modules in `test`. This greatly simplifies test loading.