### PR TITLE
Suppress THIS_IS_UNDEFINED warnings in Rollup

### DIFF
--- a/lib/to-named-amd.js
+++ b/lib/to-named-amd.js
@@ -13,6 +13,14 @@ module.exports = function toNamedAMD(tree, options = {}) {
   let entry = options.entry || path.join(namespace, 'index.js');
   let dest = options.dest || path.join('amd', 'es5', namespace.replace(/\//g, '-').replace('@', '') + '.js');
   let external = options.external || [];
+  let onwarn = options.onwarn || function(warning) {
+    // Suppress known error message caused by TypeScript compiled code with Rollup
+    // https://github.com/rollup/rollup/wiki/Troubleshooting#this-is-undefined
+    if (warning.code === 'THIS_IS_UNDEFINED') {
+      return;
+    }
+    console.log("Rollup warning: ", warning.message);
+  };
 
   let namespacedTree = toNamespacedTree(tree, namespace);
 
@@ -22,6 +30,7 @@ module.exports = function toNamedAMD(tree, options = {}) {
       dest,
       external,
       plugins,
+      onwarn,
       format: 'amd',
       moduleId: namespace,
       exports: 'named'


### PR DESCRIPTION
This fixes a known issue caused by using TypeScript compiled code with Rollup.

See https://github.com/rollup/rollup/wiki/Troubleshooting#this-is-undefine

Note that this default can be overridden via `options.onwarn`.