### PR TITLE
change broccoli-typescript-compiler dep version from `next` to actual version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "broccoli-merge-trees": "^1.2.1",
     "broccoli-rollup": "^1.0.3",
     "broccoli-string-replace": "^0.1.1",
-    "broccoli-typescript-compiler": "next",
+    "broccoli-typescript-compiler": "2.0.0-beta.1",
     "loader.js": "^4.0.11",
     "qunitjs": "^2.3.3",
     "resolve": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -805,7 +805,7 @@ broccoli-string-replace@^0.1.1:
     broccoli-persistent-filter "^1.1.5"
     minimatch "^3.0.3"
 
-broccoli-typescript-compiler@next:
+broccoli-typescript-compiler@2.0.0-beta.1:
   version "2.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/broccoli-typescript-compiler/-/broccoli-typescript-compiler-2.0.0-beta.1.tgz#42ffa780079bb6363fccabd6d16eb06328ea2a53"
   dependencies:


### PR DESCRIPTION
`next` tag no longer exists

fixes #47

***

The latest version is 2.1.0, but when I upgraded the one of the tests no longer passes, so punted on that for this PR.