### PR TITLE
Migrate from qunitjs to qunit as a dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function(options = {}) {
       annotation: 'loader.js'
     }));
 
-    trees.push(funnelLib('qunitjs', {
+    trees.push(funnelLib('qunit', {
       include: ['qunit.js', 'qunit.css'],
       annotation: 'test/qunit.{js|css}'
     }));

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "broccoli-string-replace": "^0.1.1",
     "broccoli-typescript-compiler": "2.0.0-beta.1",
     "loader.js": "^4.0.11",
-    "qunitjs": "^2.3.3",
+    "qunit": "^2.4.1",
     "resolve": "^1.3.2",
     "stack-trace": "^0.0.9",
     "testem": "^1.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,9 +2479,9 @@ quick-temp@^0.1.0, quick-temp@^0.1.3:
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunitjs@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.3.3.tgz#456696bdd61a2c8b5bc8f053f00e20d75a73d539"
+qunit@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.4.1.tgz#373c826b3b91795f3e5479cc94f0f6fa14dedc47"
   dependencies:
     chokidar "1.6.1"
     commander "2.9.0"


### PR DESCRIPTION
Allows using Node 8 (qunitjs@2.3 had issues with engines), and removes a deprecation notice folks get when consuming.