### PR TITLE
Include test-support directory in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "files": [
     "index.js",
-    "lib"
+    "lib",
+    "test-support"
   ],
   "contributors": [
     "Dan Gebhardt <dan@cerebris.com>",


### PR DESCRIPTION
This directory is required to build for a test env.