### PR TITLE
Output amd/es2017

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,11 @@ module.exports = function(options = {}) {
     let types = selectTypesFromTree(es2017ModulesAndTypes);
     let es5Modules = toES5(es2017Modules, { sourceMap: 'inline' }, options.buildType);
     let es5Amd = toNamedAmd(es5Modules, { namespace: projectName, external });
+    let es2017Amd = toNamedAmd(es2017Modules, {
+      namespace: projectName,
+      external,
+      lang: 'es2017'
+    });
     let es2017CommonJs = toNamedCommonJs(es2017Modules);
     let es5CommonJs = toNamedCommonJs(es5Modules);
 
@@ -157,6 +162,7 @@ module.exports = function(options = {}) {
       annotation: 'modules-es5'
     }));
     trees.push(es5Amd);
+    trees.push(es2017Amd);
     trees.push(funnel(es2017CommonJs, {
       destDir: 'commonjs/es2017',
       annotation: 'commonjs-es2017'

--- a/lib/to-named-amd.js
+++ b/lib/to-named-amd.js
@@ -9,7 +9,8 @@ module.exports = function toNamedAMD(tree, options = {}) {
   let namespace = options.namespace || getPackageName(process.cwd());
   let plugins = options.plugins || [];
   let entry = options.entry || path.join(namespace, 'index.js');
-  let dest = options.dest || path.join('amd', 'es5', namespace.replace(/\//g, '-').replace('@', '') + '.js');
+  let lang = options.lang || 'es5';
+  let dest = options.dest || path.join('amd', lang, namespace.replace(/\//g, '-').replace('@', '') + '.js');
   let external = options.external || [];
   let onwarn = options.onwarn || function(warning) {
     // Suppress known error message caused by TypeScript compiled code with Rollup


### PR DESCRIPTION
Although removing AMD support from @glimmer/build is a priority, it will be a breaking change.

As an intermediate step towards more modern builds, a new amd/es2017 target allows libs to continue to use amd to test more modern JS.